### PR TITLE
Upgrade jetbrains plugin, kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ targetCompatibility = 1.8
 
 apply plugin: 'java'
 apply plugin: 'kotlin'
+apply plugin: 'kotlin-kapt'
 
 
 repositories {
@@ -38,8 +39,6 @@ sourceSets {
             exclude 'website/debug_howto.png'
         }
     }
-
-    main.java.srcDirs += 'build/generated/source/kapt/main'
 }
 
 kapt {
@@ -74,10 +73,6 @@ dependencies {
     testCompile "com.google.truth:truth:0.30"
 
 
-}
-
-configurations {
-    compile.exclude module: 'idea'
 }
 
 task(verifySetup) << {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 
-    ext.kotlin_version = '1.0.4'
+    ext.kotlin_version = '1.1.3'
 
     repositories {
         mavenCentral()
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.1.10"
+    id "org.jetbrains.intellij" version "0.2.15"
 }
 
 sourceCompatibility = 1.8
@@ -51,12 +51,10 @@ if (!hasProperty('StudioCompilePath')) {
 }
 
 intellij {
-    version 'IC-15.0.5' // this value is not important, as long as you can compile
-
     pluginName 'adb_idea'
     updateSinceUntilBuild false
 
-    intellij.alternativeIdePath = project.hasProperty("StudioRunPath") ? StudioRunPath : StudioCompilePath
+    intellij.localPath = project.hasProperty("StudioRunPath") ? StudioRunPath : StudioCompilePath
 }
 
 group 'com.developerphil.intellij.plugin.adbidea'


### PR DESCRIPTION
I was trying to make some code/feature changes, but got repeatedly stuck when downloading Idea. 

This resulted in being forced to bump intellij plugin version, which forced me to bump kotlin version. Good news is now it's not necessary to download any Idea versions if they won't be used for compiling or running.

There's a known problem when `./gradlew buildPlugin` which fails to compile. However if run twice it works. Unfortunately I can't reproduce the problem on master, because it's being impossible for me to download Idea, it always times out.

Compiling and dry-run are good for 2.4 preview 7 and 3.0 preview 8. There's a minor code change necessary though, I'm not sure whether merging this is a good idea, but you have far more experience in backwards compatibility than me.
