### PR TITLE
Actions to enable/disable demo mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 
-    ext.kotlin_version = '1.1.3'
+    ext.kotlin_version = '1.2.50'
 
     repositories {
         mavenCentral()

--- a/src/main/java/com/developerphil/adbidea/action/DisableDemoModeAction.kt
+++ b/src/main/java/com/developerphil/adbidea/action/DisableDemoModeAction.kt
@@ -1,0 +1,11 @@
+package com.developerphil.adbidea.action
+
+import com.developerphil.adbidea.adb.AdbFacade
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+
+class DisableDemoModeAction : AdbAction() {
+    override fun actionPerformed(e: AnActionEvent, project: Project) {
+        AdbFacade.disableDemoModeAction(project)
+    }
+}

--- a/src/main/java/com/developerphil/adbidea/action/EnableDemoModeAction.kt
+++ b/src/main/java/com/developerphil/adbidea/action/EnableDemoModeAction.kt
@@ -1,0 +1,11 @@
+package com.developerphil.adbidea.action
+
+import com.developerphil.adbidea.adb.AdbFacade
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+
+class EnableDemoModeAction : AdbAction() {
+    override fun actionPerformed(e: AnActionEvent, project: Project) {
+        AdbFacade.enableDemoModeAction(project)
+    }
+}

--- a/src/main/java/com/developerphil/adbidea/action/QuickListAction.java
+++ b/src/main/java/com/developerphil/adbidea/action/QuickListAction.java
@@ -25,6 +25,8 @@ public class QuickListAction extends QuickSwitchSchemeAction implements DumbAwar
         addAction("com.developerphil.adbidea.action.ClearDataAction", group);
         addAction("com.developerphil.adbidea.action.ClearDataAndRestartAction", group);
         addAction("com.developerphil.adbidea.action.RevokePermissionsAction", group);
+        addAction("com.developerphil.adbidea.action.EnableDemoModeAction", group);
+        addAction("com.developerphil.adbidea.action.DisableDemoModeAction", group);
 
         if (isDebuggingAvailable()) {
             group.addSeparator();

--- a/src/main/java/com/developerphil/adbidea/adb/AdbFacade.java
+++ b/src/main/java/com/developerphil/adbidea/adb/AdbFacade.java
@@ -61,6 +61,14 @@ public class AdbFacade {
         executeOnDevice(project, new ClearDataAndRestartCommand());
     }
 
+    public static void enableDemoModeAction(Project project) {
+        executeOnDevice(project, new EnableDemoModeCommand());
+    }
+
+    public static void disableDemoModeAction(Project project) {
+        executeOnDevice(project, new DisableDemoModeCommand());
+    }
+
     private static void executeOnDevice(final Project project, final Command runnable) {
 
         if (isGradleSyncInProgress(project)) {

--- a/src/main/java/com/developerphil/adbidea/adb/command/DisableDemoModeCommand.kt
+++ b/src/main/java/com/developerphil/adbidea/adb/command/DisableDemoModeCommand.kt
@@ -1,0 +1,20 @@
+package com.developerphil.adbidea.adb.command
+
+import com.android.ddmlib.IDevice
+import com.developerphil.adbidea.adb.command.receiver.GenericReceiver
+import com.developerphil.adbidea.ui.NotificationHelper
+import com.intellij.openapi.project.Project
+import org.jetbrains.android.facet.AndroidFacet
+import java.util.concurrent.TimeUnit
+
+class DisableDemoModeCommand : Command {
+    override fun run(project: Project?, device: IDevice?, facet: AndroidFacet?, packageName: String?): Boolean =
+            try {
+                device?.executeShellCommand("am broadcast -a com.android.systemui.demo --es command exit", GenericReceiver(), 15L, TimeUnit.SECONDS)
+                        ?: NotificationHelper.error("Cannont exit Demo mode on a null device")
+                true
+            } catch (e: Exception) {
+                NotificationHelper.error("Exit Demo mode failed... " + e.message)
+                false
+            }
+}

--- a/src/main/java/com/developerphil/adbidea/adb/command/EnableDemoModeCommand.kt
+++ b/src/main/java/com/developerphil/adbidea/adb/command/EnableDemoModeCommand.kt
@@ -1,0 +1,38 @@
+package com.developerphil.adbidea.adb.command
+
+import com.android.ddmlib.IDevice
+import com.developerphil.adbidea.adb.command.receiver.GenericReceiver
+import com.developerphil.adbidea.ui.NotificationHelper
+import com.intellij.openapi.project.Project
+import org.jetbrains.android.facet.AndroidFacet
+import java.util.concurrent.TimeUnit
+
+class EnableDemoModeCommand(
+        private val hour: Int = 12,
+        private val minute: Int = 34,
+        private val batteryPower: Int = 100,
+        private val batteryPlugged: Boolean = false,
+        private val showWifiNetwork: Boolean = true,
+        private val showMobileNetwork: Boolean = false,
+        private val showNotifications: Boolean = false) : Command {
+
+    override fun run(project: Project?, device: IDevice?, facet: AndroidFacet?, packageName: String?): Boolean =
+            try {
+                device?.run {
+                    executeShellCommand("am broadcast -a com.android.systemui.demo --es command enter", GenericReceiver(), 15L, TimeUnit.SECONDS)
+                    executeShellCommand("am broadcast -a com.android.systemui.demo --es command clock --es hhmm $hour$minute", GenericReceiver(), 15L, TimeUnit.SECONDS)
+                    executeShellCommand("am broadcast -a com.android.systemui.demo --es command battery --es level $batteryPower --es plugged ${if (batteryPlugged) "true" else "false"}", GenericReceiver(), 15L, TimeUnit.SECONDS)
+                    executeShellCommand("am broadcast -a com.android.systemui.demo --es command network --es wifi ${if (showWifiNetwork) "show" else "hide"} --es fully true --es level 4", GenericReceiver(), 15L, TimeUnit.SECONDS)
+                    executeShellCommand("am broadcast -a com.android.systemui.demo --es command network --es mobile ${if (showMobileNetwork) "show" else "hide"} --es fully true --es level 4 --es datatype lte", GenericReceiver(), 15L, TimeUnit.SECONDS)
+                    executeShellCommand("am broadcast -a com.android.systemui.demo --es command notifications --es visible ${if (showNotifications) "true" else "false"}", GenericReceiver(), 15L, TimeUnit.SECONDS)
+
+                    NotificationHelper.info("Demo mode enabled")
+                } ?: NotificationHelper.error("Cannont toggle Demo mode on a null device")
+
+                true
+            } catch (e: Exception) {
+                NotificationHelper.error("Toggling Demo mode failed... " + e.message)
+                false
+            }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -190,6 +190,19 @@
                     text="ADB Restart App With Debugger"
                     description="Restarts the current application and attach the debugger">
             </action>
+
+            <action id="com.developerphil.adbidea.action.EnableDemoModeAction"
+                class="com.developerphil.adbidea.action.EnableDemoModeAction"
+                text="ADB Enable Demo mode"
+                description="Enable the Demo mode">
+            </action>
+
+            <action id="com.developerphil.adbidea.action.DisableDemoModeAction"
+                class="com.developerphil.adbidea.action.DisableDemoModeAction"
+                text="ADB Disable Demo mode"
+                description="Disable the Demo mode">
+            </action>
+
             <add-to-group group-id="AndroidToolsGroup" anchor="first"/>
         </group>
     </actions>


### PR DESCRIPTION
![adb-idea-demomode-1](https://user-images.githubusercontent.com/883959/42276935-eac44e8a-7f95-11e8-8fdc-2a1375e364cb.png) ![adb-idea-demomode-2](https://user-images.githubusercontent.com/883959/42277047-4ed9e380-7f96-11e8-9cf0-84c567f4eade.png)


2 new actions about Android Demo mode :
- **ADB Enable Demo mode**: Simplify the statusbar. For instance choose the datetime, choose the WIFI/Mobile status, hide notifications. *It helps when you want to make a screenshot of your app.*
- **ADB Disable Demo mode**: Just go back in normal mode.

I also took advantage of this PR to bump **Kotlin to 1.2.50**.