### PR TITLE
Switch layout bounds added as a new command

### DIFF
--- a/src/main/kotlin/com/developerphil/adbidea/action/SwitchLayoutBounds.kt
+++ b/src/main/kotlin/com/developerphil/adbidea/action/SwitchLayoutBounds.kt
@@ -1,0 +1,9 @@
+package com.developerphil.adbidea.action
+
+import com.developerphil.adbidea.adb.AdbFacade
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+
+class SwitchLayoutBounds : AdbAction() {
+    override fun actionPerformed(e: AnActionEvent, project: Project) = AdbFacade.switchLayoutBounds(project)
+}

--- a/src/main/kotlin/com/developerphil/adbidea/adb/AdbFacade.kt
+++ b/src/main/kotlin/com/developerphil/adbidea/adb/AdbFacade.kt
@@ -28,6 +28,7 @@ object AdbFacade {
     fun disableWifi(project: Project) = executeOnDevice(project, ToggleSvcCommand(WIFI, false))
     fun enableMobile(project: Project) = executeOnDevice(project, ToggleSvcCommand(MOBILE, true))
     fun disableMobile(project: Project) = executeOnDevice(project, ToggleSvcCommand(MOBILE, false))
+    fun switchLayoutBounds(project: Project) = executeOnDevice(project, SwitchLayoutBoundsCommand())
 
     private fun executeOnDevice(project: Project, runnable: Command) {
         if (AdbUtil.isGradleSyncInProgress(project)) {

--- a/src/main/kotlin/com/developerphil/adbidea/adb/command/SwitchLayoutBoundsCommand.kt
+++ b/src/main/kotlin/com/developerphil/adbidea/adb/command/SwitchLayoutBoundsCommand.kt
@@ -1,0 +1,37 @@
+package com.developerphil.adbidea.adb.command
+
+import com.android.ddmlib.IDevice
+import com.developerphil.adbidea.adb.command.receiver.GenericReceiver
+import com.developerphil.adbidea.adb.command.receiver.ResponseHolder
+import com.developerphil.adbidea.adb.command.receiver.ResponseReceiver
+import com.developerphil.adbidea.ui.NotificationHelper.error
+import com.developerphil.adbidea.ui.NotificationHelper.info
+import com.intellij.openapi.project.Project
+import org.jetbrains.android.facet.AndroidFacet
+import java.util.concurrent.TimeUnit
+
+
+
+class SwitchLayoutBoundsCommand() : Command {
+
+
+    override fun run(project: Project, device: IDevice, facet: AndroidFacet, packageName: String): Boolean {
+        try {
+            val receiver = ResponseHolder()
+            device.executeShellCommand("getprop debug.layout", ResponseReceiver(receiver), 30L, TimeUnit.SECONDS)
+            val isAlreadyOn = receiver.response.contains("true")
+            val cmd = if(isAlreadyOn){
+                "setprop debug.layout false && service call activity 1599295570" //SYSPROPS_TRANSACTION
+            } else {
+                "setprop debug.layout true && service call activity 1599295570" //SYSPROPS_TRANSACTION
+            }
+            device.executeShellCommand(cmd, ResponseReceiver(receiver), 30L, TimeUnit.SECONDS)
+
+            info(String.format("<b>%s</b> on %s", if(isAlreadyOn)"Hide layout bound" else "Show layout bound", device.name))
+            return true
+        } catch (e: Exception) {
+            error("Failure while attempting to switch layout bounds on ${device.name}: " + e.message)
+        }
+        return false
+    }
+}

--- a/src/main/kotlin/com/developerphil/adbidea/adb/command/receiver/ResponseReceiver.kt
+++ b/src/main/kotlin/com/developerphil/adbidea/adb/command/receiver/ResponseReceiver.kt
@@ -1,0 +1,24 @@
+package com.developerphil.adbidea.adb.command.receiver
+
+import com.android.ddmlib.MultiLineReceiver
+import java.util.*
+import java.util.regex.Pattern
+
+data class ResponseHolder(var response: String = "")
+
+class ResponseReceiver(val responseHolder: ResponseHolder)  : MultiLineReceiver() {
+
+    val adbOutputLines: MutableList<String> = ArrayList()
+
+    override fun processNewLines(lines: Array<String>) {
+        adbOutputLines.addAll(listOf(*lines))
+        for (line in lines) {
+            if (line.isNotEmpty()) {
+                responseHolder.response += "$line\n"
+            }
+        }
+    }
+
+    override fun isCancelled() = false
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -251,6 +251,12 @@
                     description="Disable mobile data on device or emulator">
             </action>
 
+            <action id="com.developerphil.adbidea.action.SwitchLayoutBounds"
+                    class="com.developerphil.adbidea.action.SwitchLayoutBounds"
+                    text="ADB Switch Layout Bounds"
+                    description="Switches (Developer Tools -> Show Layout Bounds) on device">
+            </action>
+
         </group>
     </actions>
 


### PR DESCRIPTION
In this branch I've added an option to switch "Show Layout Bounds"
I've always needed this option on my IDE and other options such as the command in terminal, or Dev Tools app does not fit very well specially when you are running on multiple devices and have to worry about the `-s` option and an `adb device`:D. As a result, I've decided to create a plugin and found your great repo and forked it.

I would be so happy if you merge this feature in the plugin so others can also use it

How I did this:
I've added ResponseReceiver class which keeps the executed command's response using a data class called `ResponseHolder` and then I run `getprop debug.layout` to see if it is enabled or not. After that, I call `setprop debug.layout false/true` and subsequently, I poke the system to refresh settings using `service call activity 1599295570`
https://susuthapa19961227.medium.com/enable-layout-debugging-in-android-using-adb-64016d755441