### PR TITLE
[New command] Toggle Don't Keep Activity

### DIFF
--- a/src/main/kotlin/com/developerphil/adbidea/action/ToggleDontKeepActivityCommandAction.kt
+++ b/src/main/kotlin/com/developerphil/adbidea/action/ToggleDontKeepActivityCommandAction.kt
@@ -1,0 +1,10 @@
+package com.developerphil.adbidea.action
+
+import com.developerphil.adbidea.adb.AdbFacade
+import com.developerphil.adbidea.adb.AdbUtil
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+
+class ToggleDontKeepActivityCommandAction : AdbAction() {
+    override fun actionPerformed(e: AnActionEvent, project: Project) = AdbFacade.toggleDontKeepActivityCommand(project)
+}

--- a/src/main/kotlin/com/developerphil/adbidea/adb/AdbFacade.kt
+++ b/src/main/kotlin/com/developerphil/adbidea/adb/AdbFacade.kt
@@ -24,6 +24,7 @@ object AdbFacade {
     fun clearData(project: Project) = executeOnDevice(project, ClearDataCommand())
     fun clearDataAndRestart(project: Project) = executeOnDevice(project, ClearDataAndRestartCommand())
     fun clearDataAndRestartWithDebugger(project: Project) = executeOnDevice(project, ClearDataAndRestartWithDebuggerCommand())
+    fun toggleDontKeepActivityCommand(project: Project) = executeOnDevice(project, ToggleDontKeepActivityCommand())
     fun enableWifi(project: Project) = executeOnDevice(project, ToggleSvcCommand(WIFI, true))
     fun disableWifi(project: Project) = executeOnDevice(project, ToggleSvcCommand(WIFI, false))
     fun enableMobile(project: Project) = executeOnDevice(project, ToggleSvcCommand(MOBILE, true))

--- a/src/main/kotlin/com/developerphil/adbidea/adb/command/ToggleDontKeepActivityCommand.kt
+++ b/src/main/kotlin/com/developerphil/adbidea/adb/command/ToggleDontKeepActivityCommand.kt
@@ -1,0 +1,26 @@
+package com.developerphil.adbidea.adb.command
+
+import com.android.ddmlib.IDevice
+import com.developerphil.adbidea.adb.command.receiver.GenericReceiver
+import com.developerphil.adbidea.ui.NotificationHelper.error
+import com.developerphil.adbidea.ui.NotificationHelper.info
+import com.intellij.openapi.project.Project
+import org.jetbrains.android.facet.AndroidFacet
+import java.util.concurrent.TimeUnit
+
+class ToggleDontKeepActivityCommand : Command {
+    override fun run(project: Project, device: IDevice, facet: AndroidFacet, packageName: String): Boolean {
+        try {
+            val getCurrentSettingReceiver = GenericReceiver()
+            device.executeShellCommand("settings get global always_finish_activities", getCurrentSettingReceiver, 15L, TimeUnit.SECONDS)
+            val currentValue = getCurrentSettingReceiver.adbOutputLines.lastOrNull { it.isNotBlank() }?.toIntOrNull() ?: 0
+            val newValue = (currentValue + 1) % 2
+            device.executeShellCommand("settings put global always_finish_activities $newValue", GenericReceiver(), 15L, TimeUnit.SECONDS)
+            info("Toggle Don't Keep Activity from $currentValue to $newValue")
+            return true
+        } catch (e1: Exception) {
+            error("Toggle Don't Keep Activity fail... " + e1.message)
+        }
+        return false
+    }
+}

--- a/src/main/kotlin/com/developerphil/adbidea/ui/MyDeviceChooser.kt
+++ b/src/main/kotlin/com/developerphil/adbidea/ui/MyDeviceChooser.kt
@@ -360,6 +360,7 @@ class MyDeviceChooser(
             return EnumSet.noneOf(HardwareFeature::class.java)
         }
 
+        @OptIn(ExperimentalStdlibApi::class)
         private fun getDeviceState(device: IDevice): String {
             val state = device.state
             return if (state != null) StringUtil.capitalize(state.name.lowercase(Locale.getDefault())) else ""

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -258,6 +258,12 @@
                     description="Disable mobile data on device or emulator">
             </action>
 
+            <action id="com.developerphil.adbidea.action.ToggleDontKeepActivityCommandAction"
+                    class="com.developerphil.adbidea.action.ToggleDontKeepActivityCommandAction"
+                    text="ADB Toggle Don't Keep Activity"
+                    description="Toggle Don't Keep Activity developer setting on device or emulator">
+            </action>
+
         </group>
     </actions>
 


### PR DESCRIPTION
Add new command "Toggle Don't Keep Activity". As its name suggests, it toggle the developper param `always_finish_activities` and avoid a long trip into Android settings.

Equivalent to `adb shell settings put global always_finish_activities [0|1]`

I had to add an `@OptIn(ExperimentalStdlibApi::class)` to make the plugin build, maybe I used a different Kotlin compiler version?