### PR TITLE
Add -a android.intent.action.MAIN to the launch command

### DIFF
--- a/src/main/kotlin/com/developerphil/adbidea/adb/ShellCommandsFactory.kt
+++ b/src/main/kotlin/com/developerphil/adbidea/adb/ShellCommandsFactory.kt
@@ -5,6 +5,6 @@ object ShellCommandsFactory {
     @JvmStatic
     fun startActivity(packageName: String, activityName: String, attachDebugger: Boolean): String {
         val debugFlag = if (attachDebugger) "-D " else ""
-        return "am start $debugFlag-n $packageName/$activityName"
+        return "am start -a android.intent.action.MAIN $debugFlag-n $packageName/$activityName"
     }
 }

--- a/src/test/kotlin/com/developerphil/adbidea/adb/ShellCommandsFactoryTest.kt
+++ b/src/test/kotlin/com/developerphil/adbidea/adb/ShellCommandsFactoryTest.kt
@@ -13,7 +13,7 @@ class ShellCommandsFactoryTest {
                 activityName = "com.example.MyActivity",
                 attachDebugger = false)
 
-        assertThat(command).isEqualTo("am start -n com.example/com.example.MyActivity")
+        assertThat(command).isEqualTo("am start -a android.intent.action.MAIN -n com.example/com.example.MyActivity")
     }
 
     @Test
@@ -23,6 +23,6 @@ class ShellCommandsFactoryTest {
                 activityName = "com.example.MyActivity",
                 attachDebugger = true)
 
-        assertThat(command).isEqualTo("am start -D -n com.example/com.example.MyActivity")
+        assertThat(command).isEqualTo("am start -a android.intent.action.MAIN -D -n com.example/com.example.MyActivity")
     }
 }


### PR DESCRIPTION
### Summary

This pull request makes a small adjustment to the ADB command used by the plugin to restart or launch an app’s default activity. Previously, the command did not include any explicit action. Now we add `-a android.intent.action.MAIN` so that apps that depend on having `MAIN` set will correctly initialize on startup.

### Why this change is necessary

In some apps, certain startup logic or navigation flows only kick in if the incoming Intent has `action=MAIN`. Without that action, the app might show a blank screen or skip important setup steps. By explicitly including `android.intent.action.MAIN`, we ensure that those apps can use ADB Idea without unexpected behavior. 

### Impact on Other Users

- Low Risk: Most Android apps already declare their default (launcher) activity to handle the `MAIN` action. Adding it explicitly shouldn’t break anything for them.
- Optional Nature: If an app doesn’t rely on `MAIN`, it should work exactly as before. This is simply a more explicit way to handle typical launcher activity scenarios.
- Potential Benefits: Any app that needs the `MAIN` action for initialization will now behave correctly on restart or launch via the plugin.

### Implementation Details

- Modified the shell command to include `-a android.intent.action.MAIN` when launching the default activity.
- Preserved all other flags and existing functionality (including debug attach).

---

Specifically, the plugin retrieves the default activity name via `getDefaultActivityName(...)`, which uses `DefaultActivityLocator` to identify the main launcher activity. Change ensures that the final ADB command explicitly includes `-a android.intent.action.MAIN` when starting that activity, preserving the intended behavior for apps that rely on MAIN for their initial setup.